### PR TITLE
Acceleration limit parameter

### DIFF
--- a/ur_description/urdf/ur.ros2_control.xacro
+++ b/ur_description/urdf/ur.ros2_control.xacro
@@ -4,7 +4,7 @@
   <xacro:macro name="ur_ros2_control" params="name prefix
     use_fake_hardware:=false fake_sensor_commands:=false
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
-    robot_ip">
+    robot_ip acceleration_limit">
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -12,6 +12,7 @@
           <plugin>fake_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
+          <param name="acceleration_limit">${acceleration_limit}</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robot_interface/universal_robots/UniversalRobotsInterface</plugin>

--- a/ur_description/urdf/ur.urdf.xacro
+++ b/ur_description/urdf/ur.urdf.xacro
@@ -10,6 +10,7 @@
    <xacro:arg name="prefix" default="ur5_" />
    <xacro:arg name="connected_to" default="" />
    <xacro:arg name="robot_ip" default="" />
+   <xacro:arg name="acceleration_limit" default="30.0" />
    <xacro:arg name="transmission_hw_interface" default=""/>
    <xacro:arg name="safety_limits" default="false"/>
    <xacro:arg name="safety_pos_margin" default="0.15"/>
@@ -27,6 +28,7 @@
      prefix="$(arg prefix)"
      robot_ip="$(arg robot_ip)"
      connected_to="$(arg connected_to)"
+     acceleration_limit="$(arg acceleration_limit)"
      joint_limits_parameters_file="${model_config_path}/joint_limits.yaml"
      kinematics_parameters_file="${model_config_path}/default_kinematics.yaml"
      physical_parameters_file="${model_config_path}/physical_parameters.yaml"

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -57,6 +57,7 @@
     prefix
     connected_to:=''
     robot_ip
+    acceleration_limit
     joint_limits_parameters_file
     kinematics_parameters_file
     physical_parameters_file
@@ -84,7 +85,8 @@
       use_fake_hardware="$(arg use_fake_hardware)"
       initial_positions="${initial_positions}"
       fake_sensor_commands="$(arg fake_sensor_commands)"
-      robot_ip="$(arg robot_ip)"/>
+      robot_ip="$(arg robot_ip)"
+      acceleration_limit="$(arg acceleration_limit)"/>
 
     <!-- Add URDF transmission elements (for ros_control) -->
     <!--<xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />-->


### PR DESCRIPTION
* Add ros2 control hardware parameter acceleration limit and pass parameter from top level

TODO: look into connected_to, since it seems to fail. The generated URDF cannot be loaded by ros2 control hardware manager.