### PR TITLE
Elide TCP FT sensor with argument

### DIFF
--- a/ur_description/urdf/ur.ros2_control.xacro
+++ b/ur_description/urdf/ur.ros2_control.xacro
@@ -3,6 +3,7 @@
 
   <xacro:macro name="ur_ros2_control" params="name prefix
     use_fake_hardware:=false fake_sensor_commands:=false
+    use_tcp_fts_sensor:=false
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
     robot_ip">
 
@@ -102,14 +103,16 @@
         <state_interface name="effort"/>
         <param name="initial_position">${initial_positions['wrist_3_joint']}</param>  <!-- initial position for the FakeSystem -->
       </joint>
-      <sensor name="tcp_fts_sensor">
-        <state_interface name="force.x"/>
-        <state_interface name="force.y"/>
-        <state_interface name="force.z"/>
-        <state_interface name="torque.x"/>
-        <state_interface name="torque.y"/>
-        <state_interface name="torque.z"/>
-      </sensor>
+      <xacro:if value="${use_tcp_fts_sensor}">
+        <sensor name="tcp_fts_sensor">
+          <state_interface name="force.x"/>
+          <state_interface name="force.y"/>
+          <state_interface name="force.z"/>
+          <state_interface name="torque.x"/>
+          <state_interface name="torque.y"/>
+          <state_interface name="torque.z"/>
+        </sensor>
+      </xacro:if>
     </ros2_control>
   </xacro:macro>
 

--- a/ur_description/urdf/ur.urdf.xacro
+++ b/ur_description/urdf/ur.urdf.xacro
@@ -16,6 +16,7 @@
    <xacro:arg name="safety_k_position" default="20"/>
    <!-- ros2_control related parameters -->
    <xacro:arg name="use_fake_hardware" default="false" />
+   <xacro:arg name="use_tcp_fts_sensor" default="false" />
    <xacro:arg name="fake_sensor_commands" default="false" />
 
    <!-- locate configuration files -->

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -66,6 +66,7 @@
     safety_pos_margin:=0.15
     safety_k_position:=20
     use_fake_hardware:=false
+    use_tcp_fts_sensor:=false
     fake_sensor_commands:=false
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}">
 
@@ -82,6 +83,7 @@
     <xacro:ur_ros2_control
       name="UniversalRobotsInterface" prefix="${prefix}"
       use_fake_hardware="$(arg use_fake_hardware)"
+      use_tcp_fts_sensor="$(arg use_tcp_fts_sensor)"
       initial_positions="${initial_positions}"
       fake_sensor_commands="$(arg fake_sensor_commands)"
       robot_ip="$(arg robot_ip)"/>


### PR DESCRIPTION
* Use argument flag to suppress the force sensor state interfaces if not desired, since these otherwise conflict with the number of joints in the command interface